### PR TITLE
Free up connection data if we are not able to connect to server.

### DIFF
--- a/src/AMQP.cpp
+++ b/src/AMQP.cpp
@@ -154,8 +154,10 @@ void AMQP::sockConnect() {
 	cnn = amqp_new_connection();
 	sockfd = amqp_open_socket(host.c_str(), port);
 
-	if (sockfd<0)
+	if (sockfd<0){
+		amqp_destroy_connection(cnn);
 		throw AMQPException("AMQP cannot create socket descriptor");
+	}
 
 	//cout << "sockfd="<< sockfd  << "  pid=" <<  getpid() <<endl;
 	amqp_set_sockfd(cnn, sockfd);


### PR DESCRIPTION
We have someone writing code to keep trying to connect to the server until it's up. This is done by trying to new an AMQP object. Obviously newing an AMQP object would throw an AMQPException with message ="AMQP cannot create socket descriptor" when server is down. However we found that it's holding on some memory and it was traced down to not releasing the connection data before throwing this exception. This was eating up memory and eventually crashed. 

The fix is to free it up before throwing AMQPException.
