### PR TITLE
Wrong type conversion when adding header

### DIFF
--- a/src/AMQPMessage.cpp
+++ b/src/AMQPMessage.cpp
@@ -104,7 +104,7 @@ void AMQPMessage::addHeader(string name, amqp_bytes_t * value) {
 void AMQPMessage::addHeader(string name, uint64_t * value) {
 	char ivalue[32];
 	bzero(ivalue,32);
-	sprintf(ivalue,"%lld",(long long int)*value);
+	sprintf(ivalue,"%llu", *value);
 	headers.insert(pair<string,string>(name,string(ivalue)));
 }
 


### PR DESCRIPTION
Converting uint64_t to long long int is not right:

Example:
*value = 17857167783900549480
header is changed to long long int: "-589576289809002136"
