### PR TITLE
Clean up connection if login fails.

### DIFF
--- a/src/AMQP.cpp
+++ b/src/AMQP.cpp
@@ -168,6 +168,7 @@ void AMQP::login() {
 	if ( res.reply_type == AMQP_RESPONSE_NORMAL)
 		return;
 
+	amqp_destroy_connection(cnn);
 	throw AMQPException(&res);
 }
 


### PR DESCRIPTION
In new AMPQ, if connection is fine but logging in fails because whatever reason (wrong password, etc.), we are not cleaning up the connection and closing the fd, before throwing an exception to the client. This is causing connections lingering in "CLOSE_WAIT" state. 

The fix is to call amqp_destroy_connection(cnn) which also attempts to close the fd if it is there.
