### PR TITLE
Update src/AMQPExchange.cpp

### DIFF
--- a/src/AMQPExchange.cpp
+++ b/src/AMQPExchange.cpp
@@ -258,8 +258,10 @@ void AMQPExchange::sendPublishCommand(const char * message, const char * key) {
 }
 
 void AMQPExchange::setHeader(string name, int value) {
-	iHeaders.insert(pair<string,int>( string(name), value));
+	iHeaders[name] = value;
+	//iHeaders.insert(pair<string,int>( string(name), value));
 }
 void AMQPExchange::setHeader(string name, string value) {
-	sHeaders.insert(pair<string,string>( string(name), value));
+	sHeaders[name] = value;
+	//sHeaders.insert(pair<string,string>( string(name), value));
 }


### PR DESCRIPTION
iHeaders and sHeaders are std::map, if we want to update a map with key/value, we should use someMap[key] = value instead of insert method. We want the new value with the same key set in the map, so as to be found.
