### PR TITLE
Qos is member of AMQPQueue and not AMQPMessage

### DIFF
--- a/include/AMQPcpp.h
+++ b/include/AMQPcpp.h
@@ -115,8 +115,6 @@ class AMQPMessage {
 		void setDeliveryTag(uint32_t delivery_tag);
 
 		AMQPQueue * getQueue();
-
-		void Qos(uint32_t prefetch_size, uint16_t prefetch_count, amqp_boolean_t global );
 };
 
 
@@ -196,7 +194,8 @@ class AMQPQueue : public AMQPBase  {
 		void addEvent( AMQPEvents_e eventType, int (*event)(AMQPMessage*) );
 
 		~AMQPQueue();
-
+		
+		void Qos(uint32_t prefetch_size, uint16_t prefetch_count, amqp_boolean_t global );
 	private:
 		void sendDeclareCommand();
 		void sendDeleteCommand();


### PR DESCRIPTION
Bug introduced by commit 29096a20dcdbf875f199f36b75b3c3e690146a27
Pull request #23
