### PR TITLE
Few AMQPException fixes

### DIFF
--- a/include/AMQPcpp.h
+++ b/include/AMQPcpp.h
@@ -48,6 +48,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <exception>
 
 //export AMQP;
 using namespace std;
@@ -58,15 +59,24 @@ enum AMQPEvents_e {
 	AMQP_MESSAGE, AMQP_SIGUSR, AMQP_CANCEL, AMQP_CLOSE_CHANNEL
 };
 
-class AMQPException {
+class AMQPException : public std::exception {
 	string message;
 	int code;
 	public:
-		AMQPException(string message);
-		AMQPException(amqp_rpc_reply_t * res);
+        explicit AMQPException(string message);
+        explicit AMQPException(amqp_rpc_reply_t * res);
 
-		string   getMessage();
-		uint16_t getReplyCode();
+        // creates error message from error code provided by librabbitmq
+        AMQPException(string action, int error_code);
+
+        virtual ~AMQPException() throw() {}
+
+        string   getMessage() const;
+        uint16_t getReplyCode() const;
+
+        virtual const char* what() const throw () {
+            return message.c_str();
+        }
 };
 
 

--- a/include/AMQPcpp.h
+++ b/include/AMQPcpp.h
@@ -63,20 +63,20 @@ class AMQPException : public std::exception {
 	string message;
 	int code;
 	public:
-	explicit AMQPException(string message);
-	explicit AMQPException(amqp_rpc_reply_t * res);
-	
-	// creates error message from error code provided by librabbitmq
-	AMQPException(string action, int error_code);
-	
-	virtual ~AMQPException() throw() {}
-	
-	string   getMessage() const;
-	uint16_t getReplyCode() const;
-	
-	virtual const char* what() const throw () {
-		return message.c_str();
-	}
+		explicit AMQPException(string message);
+		explicit AMQPException(amqp_rpc_reply_t * res);
+		
+		// creates error message from error code provided by librabbitmq
+		AMQPException(string action, int error_code);
+		
+		virtual ~AMQPException() throw() {}
+		
+		string   getMessage() const;
+		uint16_t getReplyCode() const;
+		
+		virtual const char* what() const throw () {
+			return message.c_str();
+		}
 };
 
 

--- a/include/AMQPcpp.h
+++ b/include/AMQPcpp.h
@@ -63,20 +63,20 @@ class AMQPException : public std::exception {
 	string message;
 	int code;
 	public:
-        explicit AMQPException(string message);
-        explicit AMQPException(amqp_rpc_reply_t * res);
-
-        // creates error message from error code provided by librabbitmq
-        AMQPException(string action, int error_code);
-
-        virtual ~AMQPException() throw() {}
-
-        string   getMessage() const;
-        uint16_t getReplyCode() const;
-
-        virtual const char* what() const throw () {
-            return message.c_str();
-        }
+	explicit AMQPException(string message);
+	explicit AMQPException(amqp_rpc_reply_t * res);
+	
+	// creates error message from error code provided by librabbitmq
+	AMQPException(string action, int error_code);
+	
+	virtual ~AMQPException() throw() {}
+	
+	string   getMessage() const;
+	uint16_t getReplyCode() const;
+	
+	virtual const char* what() const throw () {
+		return message.c_str();
+	}
 };
 
 

--- a/src/AMQP.cpp
+++ b/src/AMQP.cpp
@@ -156,7 +156,7 @@ void AMQP::sockConnect() {
 
 	if (sockfd<0){
 		amqp_destroy_connection(cnn);
-		throw AMQPException("AMQP cannot create socket descriptor");
+        throw AMQPException("AMQP cannot create socket descriptor", sockfd);
 	}
 
 	//cout << "sockfd="<< sockfd  << "  pid=" <<  getpid() <<endl;

--- a/src/AMQP.cpp
+++ b/src/AMQP.cpp
@@ -156,7 +156,7 @@ void AMQP::sockConnect() {
 
 	if (sockfd<0){
 		amqp_destroy_connection(cnn);
-        throw AMQPException("AMQP cannot create socket descriptor", sockfd);
+		throw AMQPException("AMQP cannot create socket descriptor", sockfd);
 	}
 
 	//cout << "sockfd="<< sockfd  << "  pid=" <<  getpid() <<endl;

--- a/src/AMQPException.cpp
+++ b/src/AMQPException.cpp
@@ -12,6 +12,11 @@ AMQPException::AMQPException(string message) {
 	this->message= message;
 }
 
+AMQPException::AMQPException(string action, int error_code)
+{
+    this->message = action + " : " + amqp_error_string2(error_code);
+}
+
 AMQPException::AMQPException( amqp_rpc_reply_t * res) {
 	if( res->reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION) {
 		this->message = res->library_error ? strerror(res->library_error) : "end-of-stream";
@@ -49,10 +54,10 @@ AMQPException::AMQPException( amqp_rpc_reply_t * res) {
 	}
 }
 
-uint16_t AMQPException::getReplyCode() {
+uint16_t AMQPException::getReplyCode() const {
 	return code;
 }
 
-string AMQPException::getMessage() {
+string AMQPException::getMessage() const {
 	return message;
 }

--- a/src/AMQPException.cpp
+++ b/src/AMQPException.cpp
@@ -14,7 +14,7 @@ AMQPException::AMQPException(string message) {
 
 AMQPException::AMQPException(string action, int error_code)
 {
-    this->message = action + " : " + amqp_error_string2(error_code);
+	this->message = action + " : " + amqp_error_string2(error_code);
 }
 
 AMQPException::AMQPException( amqp_rpc_reply_t * res) {


### PR DESCRIPTION
Some small tweaks to improve error reporting.

New feature:
* New constructor which constructs error message from user-provided action and librabbitmq-provided error string.

Small fixes:
* Getters are const, allows for passing the exception as const ref.
* Class derived from std::exception. Gives the class a standard interface, and improves interoperability.
* Single-parameter constructors marked as 'explicit' to avoid accidental conversions.