### PR TITLE
Code portability

### DIFF
--- a/include/AMQPcpp.h
+++ b/include/AMQPcpp.h
@@ -37,9 +37,8 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
-#include "strings.h"
+#include <string>
 
-#include <unistd.h>
 #include <stdint.h>
 
 #include "amqp.h"

--- a/src/AMQP.cpp
+++ b/src/AMQP.cpp
@@ -87,42 +87,34 @@ void AMQP::parseCnnString( string cnnString ) {
 	string hostPortStr, userPswString;
 	string::size_type pos = cnnString.find('@');
 
-	switch (pos) {
-		case 0:
-			hostPortStr.assign(cnnString, 1, string::npos);
-			AMQP::parseHostPort(hostPortStr);
-			user = AMQPLOGIN;
-			password = AMQPPSWD;
-		break;
-		case string::npos:
-			AMQP::parseHostPort(cnnString);
-			user = AMQPLOGIN;
-			password = AMQPPSWD;
-		break;
-		default :
-			hostPortStr.assign(cnnString, pos+1, string::npos);
-			userPswString.assign(cnnString, 0, pos);
-			AMQP::parseHostPort(hostPortStr);
-			AMQP::parseUserStr(userPswString );
-		break;
+	if (0 == pos) {
+		hostPortStr.assign(cnnString, 1, string::npos);
+		AMQP::parseHostPort(hostPortStr);
+		user = AMQPLOGIN;
+		password = AMQPPSWD;
+	} if (string::npos == pos) {
+		AMQP::parseHostPort(cnnString);
+		user = AMQPLOGIN;
+		password = AMQPPSWD;
+	} else {
+		hostPortStr.assign(cnnString, pos+1, string::npos);
+		userPswString.assign(cnnString, 0, pos);
+		AMQP::parseHostPort(hostPortStr);
+		AMQP::parseUserStr(userPswString );
 	}
 }
 
 void AMQP::parseUserStr(string userString) {
 	string::size_type pos = userString.find(':');
-	switch (pos) {
-		case 0:
-			user = AMQPLOGIN;
-			password.assign(userString, 1, string::npos);
-		break;
-		case string::npos:
-			user = userString;
-			password = AMQPPSWD;
-		break;
-		default:
-			user.assign(userString, 0, pos);
-			password.assign(userString, pos+1, string::npos);
-		break;
+	if (0 == pos) {
+		user = AMQPLOGIN;
+		password.assign(userString, 1, string::npos);
+	} if (string::npos == pos) {
+		user = userString;
+		password = AMQPPSWD;
+	} else {
+		user.assign(userString, 0, pos);
+		password.assign(userString, pos+1, string::npos);
 	}
 }
 

--- a/src/AMQP.cpp
+++ b/src/AMQP.cpp
@@ -92,7 +92,7 @@ void AMQP::parseCnnString( string cnnString ) {
 		AMQP::parseHostPort(hostPortStr);
 		user = AMQPLOGIN;
 		password = AMQPPSWD;
-	} if (string::npos == pos) {
+	} else if (string::npos == pos) {
 		AMQP::parseHostPort(cnnString);
 		user = AMQPLOGIN;
 		password = AMQPPSWD;
@@ -109,7 +109,7 @@ void AMQP::parseUserStr(string userString) {
 	if (0 == pos) {
 		user = AMQPLOGIN;
 		password.assign(userString, 1, string::npos);
-	} if (string::npos == pos) {
+	} else if (string::npos == pos) {
 		user = userString;
 		password = AMQPPSWD;
 	} else {

--- a/src/AMQPException.cpp
+++ b/src/AMQPException.cpp
@@ -26,7 +26,7 @@ AMQPException::AMQPException( amqp_rpc_reply_t * res) {
 
 	if( res->reply_type == AMQP_RESPONSE_SERVER_EXCEPTION) {
 		char buf[512];
-		bzero(buf,512);
+		memset(buf,0,512);
 		this->code = 0;
 
 		if(res->reply.id == AMQP_CONNECTION_CLOSE_METHOD) {

--- a/src/AMQPExchange.cpp
+++ b/src/AMQPExchange.cpp
@@ -257,7 +257,7 @@ void AMQPExchange::sendPublishCommand(amqp_bytes_t messageByte, const char * key
 	}
 
 	props.headers.num_entries = sHeadersSpecial.size();
-	amqp_table_entry_t_ entries[props.headers.num_entries];
+	amqp_table_entry_t_ *entries = (amqp_table_entry_t_*) malloc(sizeof(amqp_table_entry_t_) * props.headers.num_entries);
 
 	int i = 0;
 	map<string, string>::iterator it;
@@ -283,6 +283,8 @@ void AMQPExchange::sendPublishCommand(amqp_bytes_t messageByte, const char * key
 		&props,
 		messageByte
 	);
+	
+	free(entries);
 
         if ( 0 > res ) {
 		throw AMQPException("AMQP Publish Fail." );

--- a/src/AMQPMessage.cpp
+++ b/src/AMQPMessage.cpp
@@ -111,7 +111,7 @@ void AMQPMessage::addHeader(string name, amqp_bytes_t * value) {
 
 void AMQPMessage::addHeader(string name, uint64_t * value) {
 	char ivalue[32];
-	bzero(ivalue,32);
+	memset(ivalue,0,32);
 	sprintf(ivalue,"%lu", *value);
 	headers[name] = string(ivalue);
 	//headers.insert(pair<string,string>(name,string(ivalue)));
@@ -119,7 +119,7 @@ void AMQPMessage::addHeader(string name, uint64_t * value) {
 
 void AMQPMessage::addHeader(string name, uint8_t * value) {
 	char ivalue[4];
-	bzero(ivalue,4);
+	memset(ivalue,0,4);
 	sprintf(ivalue,"%d",*value);
 	headers[name] = string(ivalue);
 	//headers.insert( pair<string,string>(name,string(ivalue)));

--- a/src/AMQPQueue.cpp
+++ b/src/AMQPQueue.cpp
@@ -94,7 +94,7 @@ void AMQPQueue::sendDeclareCommand() {
 
 	amqp_release_buffers(*cnn);
 	char error_message [256];
-	bzero(error_message,256);
+	memset(error_message,0,256);
 
 	if (res.reply_type == AMQP_RESPONSE_NONE) {
 		throw AMQPException("error the QUEUE.DECLARE command, response none");


### PR DESCRIPTION
These changes allow the code to be compiled with any compiler that complies with the standard, not just ones with non-standard extensions like <strings.h>, <unistd.h>, and variable-length arrays.