### PR TITLE
Updates to allow addEvent callbacks to be lambdas/std::function<> when a C++11 (or greater) compiler is used

### DIFF
--- a/include/AMQPcpp.h
+++ b/include/AMQPcpp.h
@@ -52,6 +52,9 @@
 #include <memory>
 #include <exception>
 
+#if __cplusplus > 199711L // C++11 or greater
+#include <functional>
+#endif
 //export AMQP;
 
 class AMQPQueue;
@@ -163,7 +166,11 @@ class AMQPBase {
 
 class AMQPQueue : public AMQPBase  {
 	protected:
+#if __cplusplus > 199711L // C++11 or greater
+                std::map< AMQPEvents_e, std::function<int(AMQPMessage*)> > events;
+#else
 		std::map< AMQPEvents_e, int(*)( AMQPMessage * ) > events;
+#endif
 		amqp_bytes_t consumer_tag;
 		uint32_t delivery_tag;
 		uint32_t count;
@@ -209,7 +216,9 @@ class AMQPQueue : public AMQPBase  {
 		amqp_bytes_t getConsumerTag();
 
 		void addEvent( AMQPEvents_e eventType, int (*event)(AMQPMessage*) );
-
+#if __cplusplus > 199711L // C++11 or greater
+                void addEvent( AMQPEvents_e eventType, std::function<int(AMQPMessage*)>& event );
+#endif
 		virtual ~AMQPQueue();
 		
 		void Qos(uint32_t prefetch_size, uint16_t prefetch_count, amqp_boolean_t global );


### PR DESCRIPTION
When C++11 support is detected C++11 lambdas/std::function<> objects are able to be used for addEvent callbacks. Currently the event callbacks are all assumed to be C style function pointers.

Existing functionality is maintained by wrapping the old style C function pointer in a std::function<> making this transparent to the user by the use of #define (I am assuming this is preferable rather than add a C++11 limitation on the entire library?)