### PR TITLE
Error fixes

### DIFF
--- a/src/AMQP.cpp
+++ b/src/AMQP.cpp
@@ -42,7 +42,6 @@ AMQP::~AMQP() {
 		}
 	}
 
-	amqp_channel_close(cnn, 1, AMQP_REPLY_SUCCESS);
 	amqp_connection_close(cnn, AMQP_REPLY_SUCCESS);
 	amqp_destroy_connection(cnn);
 };

--- a/src/AMQPQueue.cpp
+++ b/src/AMQPQueue.cpp
@@ -14,8 +14,6 @@ AMQPQueue::AMQPQueue(amqp_connection_state_t * cnn, int channelNum) {
 	this->cnn = cnn;
 	this->channelNum = channelNum;
 
-	consumer_tag.bytes=NULL;
-	consumer_tag.len=0;
 	delivery_tag =0;
 	pmessage=NULL;
 	openChannel();
@@ -26,8 +24,6 @@ AMQPQueue::AMQPQueue(amqp_connection_state_t * cnn, int channelNum, string name)
 	this->channelNum = channelNum;
 	this->name = name;
 
-	consumer_tag.bytes=NULL;
-	consumer_tag.len=0;
 	delivery_tag =0;
 	pmessage=NULL;
 	openChannel();
@@ -393,7 +389,7 @@ void AMQPQueue::Consume(short parms) {
 }
 
 void AMQPQueue::setConsumerTag(string consumer_tag) {
-	this->consumer_tag = amqp_cstring_bytes(consumer_tag.c_str());
+	this->consumer_tag = consumer_tag;
 }
 
 void AMQPQueue::sendConsumeCommand() {
@@ -422,7 +418,7 @@ void AMQPQueue::sendConsumeCommand() {
 	memset(&s,0,sizeof(amqp_basic_consume_t));
 		s.ticket = channelNum;
 		s.queue = queueByte;
-		s.consumer_tag = consumer_tag;
+		s.consumer_tag = amqp_cstring_bytes(consumer_tag.c_str());
 		s.no_local = ( AMQP_NOLOCAL & parms ) ? 1:0;
 		s.no_ack = ( AMQP_NOACK & parms ) ? 1:0;
 		s.exclusive = ( AMQP_EXCLUSIVE & parms ) ? 1:0;
@@ -626,25 +622,24 @@ void AMQPQueue::setHeaders(amqp_basic_properties_t * p) {
 }
 
 void AMQPQueue::Cancel(string consumer_tag){
-	this->consumer_tag = amqp_cstring_bytes(consumer_tag.c_str());
+	this->consumer_tag = consumer_tag;
 	sendCancelCommand();
 }
 
 void AMQPQueue::Cancel(amqp_bytes_t consumer_tag){
-	this->consumer_tag.len = consumer_tag.len;
-	this->consumer_tag.bytes = consumer_tag.bytes;
+	this->consumer_tag = string((char*)consumer_tag.bytes, consumer_tag.len);
 	sendCancelCommand();
 }
 
 void AMQPQueue::sendCancelCommand(){
 	amqp_basic_cancel_t s;
-		s.consumer_tag=consumer_tag;
+		s.consumer_tag= amqp_cstring_bytes(consumer_tag.c_str());
 		s.nowait=( AMQP_NOWAIT & parms ) ? 1:0;
 
 	amqp_send_method(*cnn, channelNum, AMQP_BASIC_CANCEL_METHOD, &s);
 }
 
-amqp_bytes_t AMQPQueue::getConsumerTag() {
+std::string AMQPQueue::getConsumerTag() {
 	return consumer_tag;
 }
 

--- a/src/AMQPQueue.cpp
+++ b/src/AMQPQueue.cpp
@@ -34,7 +34,6 @@ AMQPQueue::AMQPQueue(amqp_connection_state_t * cnn, int channelNum, string name)
 }
 
 AMQPQueue::~AMQPQueue() {
-	this->closeChannel();
 	if (pmessage)
 		delete pmessage;
 }


### PR DESCRIPTION
`void AMQPQueue::setConsumerTag(string consumer_tag)`
*consumer_tag* is being released when this function exits so *this->consumer_tag* becomes invalid, and then this invalid data is used in other functions.

`amqp_channel_close(cnn, 1, AMQP_REPLY_SUCCESS);`
this dosn't have related *amqp_channel_open function* and causes error on server side.

`this->closeChannel();`
*closeChannel* is called in base class for the second time which causes error on server side