### PR TITLE
Update AMQP.cpp

### DIFF
--- a/src/AMQP.cpp
+++ b/src/AMQP.cpp
@@ -84,7 +84,7 @@ void AMQP::parseCnnString( string cnnString ) {
 
 	// find '@' if Ok -> right part is host:port else all host:port
 	string hostPortStr, userPswString;
-	string::size_type pos = cnnString.find('@');
+	string::size_type pos = cnnString.find_last_of('@');
 
 	if (0 == pos) {
 		hostPortStr.assign(cnnString, 1, string::npos);


### PR DESCRIPTION
currently if in connection string(ex. "user:password_first@password_second@localhost:5672/vhost" ) password contains '@', then after parsing will be wrong( after parsing---> pass:password_first and host: password_second@localhost). so, instead of searching first '@' in parseCnnString method, searched last '@'