### PR TITLE
Allow compiling without SSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(amqpcpp)
 
+option(ENABLE_SSL_SUPPORT "Enable SSL support" ON)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -34,5 +36,10 @@ target_include_directories(amqpcpp-static PUBLIC include/)
 add_subdirectory(rabbitmq-c)
 target_include_directories(rabbitmq PRIVATE rabbitmq-c/librabbitmq/)
 
-target_link_libraries(amqpcpp rabbitmq ssl crypto)
-target_link_libraries(amqpcpp-static rabbitmq ssl crypto)
+target_link_libraries(amqpcpp rabbitmq)
+target_link_libraries(amqpcpp-static rabbitmq)
+if (ENABLE_SSL_SUPPORT)
+  add_definitions(-DWITH_SSL=1)
+  target_link_libraries(amqpcpp ssl crypto)
+  target_link_libraries(amqpcpp-static ssl crypto)
+endif()

--- a/include/AMQPcpp.h
+++ b/include/AMQPcpp.h
@@ -44,7 +44,9 @@
 #include "amqp.h"
 #include "amqp_framing.h"
 #include "amqp_tcp_socket.h"
+#ifdef WITH_SSL
 #include "amqp_ssl_socket.h"
+#endif
 
 #include <iostream>
 #include <vector>

--- a/src/AMQP.cpp
+++ b/src/AMQP.cpp
@@ -179,6 +179,7 @@ void AMQP::sockConnect() {
 
 	switch(proto) {
 		case AMQPS_proto: {
+#ifdef WITH_SSL
 			sockfd = amqp_ssl_socket_new(cnn);
 
 			status = amqp_ssl_socket_set_cacert(sockfd, cacert_path.c_str());
@@ -196,6 +197,9 @@ void AMQP::sockConnect() {
 #else
 			amqp_ssl_socket_set_verify_peer(sockfd, verify_peer ? 1 : 0);
 			amqp_ssl_socket_set_verify_hostname(sockfd, verify_hostname ? 1 : 0);
+#endif
+#else
+			throw AMQPException("AMQP cannot open SSL connection (compiled without SSL support)");
 #endif
 		}
 		break;


### PR DESCRIPTION
This PR adds the ability to compile without SSL. ```rabbitmq-c``` already has that ability, but until now compiling it without SSL lead to errors because ```amqpcpp``` always expected it to be compiled with SSL.

Since we now use the same cmake variable as in ```rabbitmq-c``` both libraries are always compiled in the same way.

An exception is raised in case the user requests a SSL connection from a library that is compiled without SSL support.