### PR TITLE
Link to the OpenSSL libraries in a portable way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,5 +34,5 @@ target_include_directories(amqpcpp-static PUBLIC include/)
 add_subdirectory(rabbitmq-c)
 target_include_directories(rabbitmq PRIVATE rabbitmq-c/librabbitmq/)
 
-target_link_libraries(amqpcpp rabbitmq ssl crypto)
-target_link_libraries(amqpcpp-static rabbitmq ssl crypto)
+target_link_libraries(amqpcpp rabbitmq ${OPENSSL_LIBRARIES})
+target_link_libraries(amqpcpp-static rabbitmq ${OPENSSL_LIBRARIES})


### PR DESCRIPTION
On Windows you need to specify the exact location of the libraries to link to. Therefore linking to ```ssl crypto``` fails. The fix proposed in this PR is to use the respective platform independent CMake-variable ```${OPENSSL_LIBRARIES}```.